### PR TITLE
Centralize `androidx-lifecycle` version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@
 
 [versions]
 agp = "8.11.0"
+androidx-lifecycle = "2.9.4"
 androidx-lint-gradle = "1.0.0-alpha05"
 anvil = "0.4.1"
 atomicfu = "0.29.0"
@@ -72,11 +73,11 @@ androidx-compose-material3 = "androidx.compose.material3:material3:1.3.2"
 androidx-compose-materialNavigation = "androidx.compose.material:material-navigation:1.9.1"
 androidx-core = "androidx.core:core-ktx:1.17.0"
 androidx-fragment = "androidx.fragment:fragment-ktx:1.8.9"
-androidx-lifecycle-runtime-compose = "androidx.lifecycle:lifecycle-runtime-compose:2.9.4"
-androidx-lint-gradle = {  module = "androidx.lint:lint-gradle", version.ref = "androidx-lint-gradle" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+androidx-lint-gradle = { module = "androidx.lint:lint-gradle", version.ref = "androidx-lint-gradle" }
 androidx-material3 = "com.google.android.material:material:1.13.0"
 androidx-navigationCompose = "androidx.navigation:navigation-compose:2.9.4"
-androidx-viewmodel = "androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.4"
+androidx-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-work = "androidx.work:work-runtime:2.10.4"
 
 anvil-annotations = { module = "dev.zacsweers.anvil:annotations", version.ref = "anvil" }


### PR DESCRIPTION
In [2.8.0](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.0) the `lifecycle-viewmodel-ktx` was also merged in `lifecycle-viewmodel` and is now completely empty.